### PR TITLE
fix: unixtimestamp calculation from PostgreSQL

### DIFF
--- a/drivers/caldav/caldav_driver.php
+++ b/drivers/caldav/caldav_driver.php
@@ -2266,7 +2266,7 @@ else {
     {
         switch ($this->rc->db->db_provider) {
             case 'postgres':
-                return "EXTRACT (EPOCH FROM $field)";
+                return "EXTRACT (EPOCH FROM $field::timestamp without time zone)";
             default:
                 return "UNIX_TIMESTAMP($field)";
         }


### PR DESCRIPTION
On a server with a timezone other than UTC, the timestamp calculation on PostgreSQL was different on the dates without timezones and the others. This lead to problems, like not triggering syncs.

see https://stackoverflow.com/questions/29536542/different-results-for-extract-epoch-on-different-postgresql-servers

Also note that this type of timestamp calculation has been deprecated upstream for a while (see https://github.com/roundcube/roundcubemail/blame/master/program/lib/Roundcube/rcube_db.php#L1035-L1049)
