### PR TITLE
fix: event edition for caldav driver

### DIFF
--- a/drivers/caldav/caldav_driver.php
+++ b/drivers/caldav/caldav_driver.php
@@ -945,6 +945,8 @@ class caldav_driver extends calendar_driver
                 $sql_set[] = $this->rc->db->quote_identifier($col) . '=' . $this->rc->db->quote($event[$col]->format(self::DB_DATE_FORMAT));
             else if (is_array($event[$col]))
                 $sql_set[] = $this->rc->db->quote_identifier($col) . '=' . $this->rc->db->quote(join(',', $event[$col]));
+            else if (array_key_exists($col, $event) && is_null($event[$col]))
+                $sql_set[] = $this->rc->db->quote_identifier($col) . '=NULL';
             else if (array_key_exists($col, $event)) {
                 //TODO: proper 4 byte character (eg emoticons) handling
                 //utf8 in mysql only supports 3 byte characters, so this throws an error if there are emoticons in the description.


### PR DESCRIPTION
Set to NULL for real in db values that equals NULL in PHP.
Without this change, events can not be edited on Postgres because it tries to set an invalid timestamp instead of NULL:

```
[28-Apr-2022 15:00:46 +0200]: <tv5na0nh> DB Error: [7] ERROR:  invalid input syntax for type timestamp: ""
LINE 2: ...atus"='', "attendees"='', "alarms"='', "notifyat"='', "calda...
                                                             ^ (SQL Query: UPDATE caldav_events
       SET   changed=now() , "start"='2022-04-29 16:00:00', "end"='2022-04-29 18:00:00', "all_day"='0', "recurrence_id"='0', "isexception"='0', "sequence"='0', "title"='test', "description"='', "location"='', "categories"='', "url"='', "free_busy"='1', "priority"='0', "sensitivity"='0', "status"='', "attendees"='', "alarms"='', "notifyat"='', "caldav_url"='/calendars/nicolas/default//D3F457A307C27F83D74BEE2AA8440C29-DEB97A759EE7B8BA.ics', "caldav_tag"=''
       WHERE event_id='378'
       AND   calendar_id IN ('22','21')) in /usr/share/roundcube/program/lib/Roundcube/rcube_db.php on line 544 (POST /?_task=calendar&_action=event)
```


Only tested on PostgreSQL
