### PR TITLE
feat: add preinstalled sources

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -143,6 +143,20 @@ $config['kolab_invitation_calendars'] = false;
 // %i - Calendar UUID
 // $config['calendar_caldav_url'] = 'http://%h/iRony/calendars/%u/%i';
 
+// List of CalDAV sources that should be allready installed.
+// They will be added when the calendar section is accessed for the first time by a user.
+// For 'caldav_user' and 'caldav_url' the following replacement variables are supported:
+// %u - Current webmail user name
+// For 'caldav_pass' %p is replaced by the current user's password.
+// $config['calendar_caldav_preinstalled_sources'] = array(
+//     'name' => array(
+//         'caldav_user' => '%u',
+//         'caldav_pass' => '%p',
+//         'caldav_url'  => 'https://example.net/dav',
+//         'showAlarms'  => 1
+//     )
+// );
+
 // Driver to provide a resource directory ('ldap' is the only implementation yet).
 // Leave empty or commented to disable resources support.
 // $config['calendar_resources_driver'] = 'ldap';

--- a/drivers/caldav/caldav_driver.php
+++ b/drivers/caldav/caldav_driver.php
@@ -110,7 +110,7 @@ class caldav_driver extends calendar_driver
      */
     protected function _setup_preinstalled_sources()
     {
-        $preinstalled_sources = $this->rc->config->get('calendar_preinstalled_sources', FALSE);
+        $preinstalled_sources = $this->rc->config->get('calendar_caldav_preinstalled_sources', FALSE);
         if ($preinstalled_sources && is_array($preinstalled_sources)) {
             $username = $this->rc->get_user_name();
             $password = $this->rc->get_user_password();


### PR DESCRIPTION
Still a work in progress but this is working quite well already. I am interested in your input.

For instance I didn't use the exact same config as the other forks as it seems the sources configuration is a little bit different from the previous calendar ones.
Also if I understood correctly, only the `caldav` driver is providing this kind of "source" support, thus I decided to remove the `driver` key.

This is also still missing the example config

Closes #1 