### PR TITLE
fix: create calendars with source ending with '/'

### DIFF
--- a/drivers/caldav/caldav_driver.php
+++ b/drivers/caldav/caldav_driver.php
@@ -240,7 +240,7 @@ class caldav_driver extends calendar_driver
             $source['caldav_pass'] = $this->_decrypt_pass($source['caldav_pass']);
 
             $server_url = self::_encode_url($source['caldav_url']);
-            $server_path = parse_url($server_url, PHP_URL_PATH);
+            $server_path = rtrim(parse_url($server_url, PHP_URL_PATH), '/');
             $calId = $this->cal->generate_uid();
             $path = "/calendars/$source[caldav_user]/$calId";
 


### PR DESCRIPTION
This fixes the following error when trying to create a calendar with a source like `https://webdav.club1.fr/` that ends with a `/`:

```
[28-Apr-2022 19:44:58 Europe/Berlin] PHP Fatal error:  Uncaught Sabre\HTTP\ClientException: Could not resolve host: calendars in /var/lib/roundcube/plugins/calendar/vendor/sabre/http/lib/Client.php:327
Stack trace:
#0 /var/lib/roundcube/plugins/calendar/vendor/sabre/http/lib/Client.php(114): Sabre\HTTP\Client->doRequest()
#1 /var/lib/roundcube/plugins/calendar/vendor/sabre/dav/lib/DAV/Client.php(367): Sabre\HTTP\Client->send()
#2 /var/lib/roundcube/plugins/calendar/drivers/caldav/caldav_client.php(390): Sabre\DAV\Client->request()
#3 /var/lib/roundcube/plugins/calendar/drivers/caldav/caldav_driver.php(252): caldav_client->create_calendar()
#4 /var/lib/roundcube/plugins/calendar/calendar.php(978): caldav_driver->create_calendar()
#5 /usr/share/roundcube/program/lib/Roundcube/rcube_plugin_api.php(494): calendar->calendar_action()
#6 /usr/share/roundcube/index.php(294): rcube_plugin_api->exec_action()
#7 {main}
  thrown in /var/lib/roundcube/plugins/calendar/vendor/sabre/http/lib/Client.php on line 327
```