### PR TITLE
Fix SQLite

### DIFF
--- a/calendar.php
+++ b/calendar.php
@@ -424,7 +424,9 @@ class calendar extends rcube_plugin
             $timeslots = $this->rc->config->get('calendar_timeslots', $this->defaults['calendar_timeslots']);
 
             $select = new html_select(['name' => '_timeslots', 'id' => $field_id]);
-            $select->add($choices);
+            foreach ($choices as $choice) {
+                $select->add($choice, $choice);
+            }
 
             $p['blocks']['view']['options']['timeslots'] = [
                 'title' => html::label($field_id, rcube::Q($this->gettext('timeslots'))),

--- a/drivers/caldav/SQL/sqlite.initial.sql
+++ b/drivers/caldav/SQL/sqlite.initial.sql
@@ -39,7 +39,7 @@ CREATE TABLE IF NOT EXISTS `caldav_calendars` (
     `showalarms` tinyINTEGER NOT NULL DEFAULT '1',
     `caldav_tag` TEXT DEFAULT NULL,
     `caldav_url` TEXT NOT NULL,
-    `caldav_last_change` timestamp NOT NULL ,
+    `caldav_last_change` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `is_ical` tinyINTEGER NOT NULL DEFAULT '0',
     `ical_user` TEXT DEFAULT NULL,
     `ical_pass` TEXT DEFAULT NULL,
@@ -78,7 +78,7 @@ CREATE TABLE IF NOT EXISTS `caldav_events` (
     `notifyat` datetime DEFAULT NULL,
     `caldav_url` TEXT NOT NULL,
     `caldav_tag` TEXT DEFAULT NULL,
-    `caldav_last_change` timestamp NOT NULL ,
+    `caldav_last_change` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (`calendar_id`)
         REFERENCES `caldav_calendars`(`calendar_id`) ON DELETE CASCADE ON UPDATE CASCADE
 );


### PR DESCRIPTION
This PR is a bug fix one for :

SQLite's support :

- fix : calendar not created due to affected_rows vs num_rows > 0 different behavior between MySQL and SQLite
- fix : event and calendar not created due to no default values for caldav_last_change field
- workaround : calendar never synched due to NOW() does not exist in SQLite in _is_synced. Help requested to do a better fix, at least it works.

UI :
- fix : calendar settings : Time slots per hour value was not correctly saved (need to set to value+1)